### PR TITLE
 Stability and speed improvements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,25 @@ CHANGES
 This file contains a brief summary of changes made from previous versions of
 the connector.
 
+1.2.0a - April 2017
+---------------------
+* Stability and speed improvements.
+
+* Removed infinite wait in read_packet() if connection dropped.
+  Merged wait_for_client() and wait_for_data() into one
+  universal wait_for_bytes(int).
+* Improved connect() speed.
+* Improved sending queries speed.
+  Sending the whole buffer at a time (not byte by byte).
+* Fixed bug with check_ok_packet() return value.
+  check_ok_packet() simplified to get_packet_type().
+* Added checks for buffer validity in places it is going to be used.
+  Improved stability on "incorrect" methods calls.
+* Restored WITH_SELECT, but defined by default.
+* Added DEBUG define to avoid prints to Serial port.
+  Useful when Serial is used to communicate with sensors.
+* Added example for ESP8266.
+
 1.1.1a - January 2016
 ---------------------
 * Minor issue with deprecated #import fixed. No new functionality.

--- a/examples/basic_insert_esp8266/basic_insert_esp8266.ino
+++ b/examples/basic_insert_esp8266/basic_insert_esp8266.ino
@@ -1,0 +1,76 @@
+/*
+  MySQL Connector/Arduino Example : connect by wifi
+
+  This example demonstrates how to connect to a MySQL server from an
+  Arduino using an Arduino-compatible Wifi shield. Note that "compatible"
+  means it must conform to the Ethernet class library or be a derivative
+  thereof. See the documentation located in the /docs folder for more
+  details.
+
+  INSTRUCTIONS FOR USE
+
+  1) Change the address of the server to the IP address of the MySQL server
+  2) Change the user and password to a valid MySQL user and password
+  3) Change the SSID and pass to match your WiFi network
+  4) Connect a USB cable to your Arduino
+  5) Select the correct board and port
+  6) Compile and upload the sketch to your Arduino
+  7) Once uploaded, open Serial Monitor (use 115200 speed) and observe
+
+  If you do not see messages indicating you have a connection, refer to the
+  manual for troubleshooting tips. The most common issues are the server is
+  not accessible from the network or the user name and password is incorrect.
+
+  Created by: Dr. Charles A. Bell
+*/
+#include <ESP8266WiFi.h>           // Use this for WiFi instead of Ethernet.h
+#include <MySQL_Connection.h>
+#include <MySQL_Cursor.h>
+
+IPAddress server_addr(10,0,1,35);  // IP of the MySQL *server* here
+char user[] = "root";              // MySQL user login username
+char password[] = "secret";        // MySQL user login password
+
+// Sample query
+char INSERT_SQL[] = "INSERT INTO test_arduino.hello_arduino (message) VALUES ('Hello, Arduino!')";
+
+// WiFi card example
+char ssid[] = "your-ssid";         // your SSID
+char pass[] = "ssid-password";     // your SSID Password
+
+WiFiClient client;                 // Use this for WiFi instead of EthernetClient
+MySQL_Connection conn(&client);
+MySQL_Cursor cursor(&conn);
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial); // wait for serial port to connect. Needed for Leonardo only
+
+  // Begin WiFi section
+  Serial.printf("\nConnecting to %s", ssid);
+  WiFi.begin(ssid, pass);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  // print out info about the connection:
+  Serial.println("\nConnected to network");
+  Serial.print("My IP address is: ");
+  Serial.println(WiFi.localIP());
+
+  Serial.print("Connecting to SQL...  ");
+  if (conn.connect(server_addr, 3306, user, password))
+    Serial.println("OK.");
+  else
+    Serial.println("FAILED.");
+}
+
+void loop()
+{
+  if (conn.connected())
+    cursor.execute(INSERT_SQL);
+
+  delay(5000);
+}

--- a/src/MySQL_Connection.cpp
+++ b/src/MySQL_Connection.cpp
@@ -34,6 +34,7 @@
 
 #define MAX_CONNECT_ATTEMPTS 3
 #define CONNECT_DELAY_MS     500
+#define SUCCESS              1
 
 const char CONNECTED[] PROGMEM = "Connected to server version ";
 const char DISCONNECTED[] PROGMEM = "Disconnected.";
@@ -64,13 +65,13 @@ boolean MySQL_Connection::connect(IPAddress server, int port, char *user,
   while (retries--)
   {
     connected = client->connect(server, port);
-    if (connected)
+    if (connected == SUCCESS)
       break;
 
     delay(CONNECT_DELAY_MS);
   }
 
-  if (!connected)
+  if (connected != SUCCESS)
     return false;
 
   read_packet();

--- a/src/MySQL_Cursor.cpp
+++ b/src/MySQL_Cursor.cpp
@@ -145,11 +145,10 @@ boolean MySQL_Cursor::execute_query(int query_len)
   if (res == MYSQL_ERROR_PACKET) {
     conn->parse_error_packet();
     return false;
-  } else if (res == MYSQL_OK_PACKET) {
+  } else if (res == MYSQL_OK_PACKET || res == MYSQL_EOF_PACKET) {
     return true;
-  } else {
-    return false;
   }
+
   // Not an Ok packet, so we now have the result set to process.
 #ifdef WITH_SELECT
   columns_read = false;

--- a/src/MySQL_Cursor.h
+++ b/src/MySQL_Cursor.h
@@ -36,8 +36,11 @@
 
 #include <MySQL_Connection.h>
 
+#define WITH_SELECT          // Comment this if you don't need SELECT queries. 
+                             // Reduces memory footprint of the library.
 #define MAX_FIELDS    0x20   // Maximum number of fields. Reduce to save memory. Default=32
 
+#ifdef WITH_SELECT
 // Structure for retrieving a field (minimal implementation).
 typedef struct {
   char *db;
@@ -55,34 +58,43 @@ typedef struct {
 typedef struct {
   char *values[MAX_FIELDS];
 } row_values;
+#endif  // WITH_SELECT
 
 class MySQL_Cursor {
   public:
     MySQL_Cursor(MySQL_Connection *connection);
-    ~MySQL_Cursor() { close(); };
+    ~MySQL_Cursor();
     boolean execute(const char *query, boolean progmem=false);
+
+  private:
+    boolean execute_query(int query_len);
+
+#ifdef WITH_SELECT
+  public:
+    void close();
     column_names *get_columns();
     row_values *get_next_row();
     void show_results();
-    void close();
 
   private:
-    boolean columns_read;
-    MySQL_Connection *conn;
-    int num_cols;
-    column_names columns;
-    row_values row;
-
     void free_columns_buffer();
     void free_row_buffer();
     bool clear_ok_packet();
-    boolean execute_query(int query_len);
+
     char *read_string(int *offset);
     int get_field(field_struct *fs);
     int get_row();
     boolean get_fields();
     int get_row_values();
     column_names *query_result();
+    
+    boolean columns_read;
+    int num_cols;
+    column_names columns;
+    row_values row;
+#endif
+
+    MySQL_Connection *conn;
 };
 
 #endif

--- a/src/MySQL_Packet.h
+++ b/src/MySQL_Packet.h
@@ -35,8 +35,6 @@
 
 #include <Ethernet.h>
 
-#define MYSQL_MAX_TIMEOUT   10
-#define MYSQL_MIN_BYTES     8
 #define MYSQL_OK_PACKET     0x00
 #define MYSQL_EOF_PACKET    0xfe
 #define MYSQL_ERROR_PACKET  0xff
@@ -59,13 +57,12 @@ class MySQL_Packet {
     void parse_handshake_packet();
     boolean scramble_password(char *password, byte *pwd_hash);
     void read_packet();
-    int check_ok_packet();
+    int get_packet_type();
     void parse_error_packet();
     int get_lcb_len(int offset);
     int read_int(int offset, int size=0);
     void store_int(byte *buff, long value, int size);
-    int wait_for_client();
-    boolean wait_for_data();
+    int wait_for_bytes(int bytes_count);
     void show_error(const char *msg, bool EOL = false);
     void print_packet();
 


### PR DESCRIPTION
- Removed infinite wait in read_packet() if connection dropped.
  Merged wait_for_client() and wait_for_data() into one
  universal wait_for_bytes(int).
- Improved connect speed.
- Improved sending queries speed.
  Sending the whole buffer at a time (not byte by byte).
- Fixed bug with check_ok_packet() return value.
  check_ok_packet() simplified to get_packet_type().
- Added checks for buffer validity in places it is going to be used.
  Improved stability on "incorrect" methods calls.
- Restored WITH_SELECT, but defined by default.
- Added DEBUG define to avoid prints to Serial port.
  Useful when Serial is used to communicate with sensors.
- Added example for ESP8266.