### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-connect       KEYWORD1
-execute       KEYWORD2
-show_results  KEYWORD3
-connected     KEYWORD4
-field_struct  KEYWORD5
+connect	KEYWORD1
+execute	KEYWORD2
+show_results	KEYWORD3
+connected	KEYWORD4
+field_struct	KEYWORD5


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords