### PR TITLE
Use correct and valid KEYWORD_TOKENTYPEs in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-connect	KEYWORD1
+connect	KEYWORD2
 execute	KEYWORD2
-show_results	KEYWORD3
-connected	KEYWORD4
-field_struct	KEYWORD5
+show_results	KEYWORD2
+connected	KEYWORD2
+field_struct	KEYWORD3


### PR DESCRIPTION
Use of the undocumented KEYWORD4 has the unexpected result of coloring the keyword as an inline comment in Arduino IDE 1.6.4 and older. Use of the undocumented KEYWORD5 has the unexpected result of coloring the keyword as a hyperlink in Arduino IDE 1.6.4 and older.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype