### PR TITLE
Reorganise reference to Client object

### DIFF
--- a/src/MySQL_Packet.h
+++ b/src/MySQL_Packet.h
@@ -33,7 +33,7 @@
 #ifndef MYSQL_PACKET_H
 #define MYSQL_PACKET_H
 
-#include <Ethernet.h>
+#include <Client.h>
 
 #define MYSQL_OK_PACKET     0x00
 #define MYSQL_EOF_PACKET    0xfe

--- a/src/MySQL_Packet.h
+++ b/src/MySQL_Packet.h
@@ -33,6 +33,7 @@
 #ifndef MYSQL_PACKET_H
 #define MYSQL_PACKET_H
 
+#include <Arduino.h>
 #include <Client.h>
 
 #define MYSQL_OK_PACKET     0x00


### PR DESCRIPTION
I propose to reference the Client object directly. For the use of non-native types (byte, etc) a reference to Arduino is needed. Tested for ESP8266.
This change is needed for the ESP32 (Does not know ethernet.h)