### PR TITLE
Fix the warnings and support constant strings

### DIFF
--- a/src/MySQL_Connection.cpp
+++ b/src/MySQL_Connection.cpp
@@ -58,8 +58,11 @@ const char DISCONNECTED[] PROGMEM = "Disconnected.";
 
   Returns boolean - True = connection succeeded
 */
-boolean MySQL_Connection::connect(IPAddress server, int port, char *user,
-                                  char *password, char *db)
+//boolean MySQL_Connection::connect(IPAddress server, int port, char *user,
+//                                  char *password, char *db)
+// Modify 'char *' into 'const char *const' so that const string can be used here
+boolean MySQL_Connection::connect(IPAddress server, int port, const char *const user,
+                                  const char *const password, const char *const db)
 {
   int connected = 0;
   int retries = MAX_CONNECT_ATTEMPTS;

--- a/src/MySQL_Connection.h
+++ b/src/MySQL_Connection.h
@@ -42,8 +42,11 @@ class MySQL_Connection : public MySQL_Packet {
   public:
     MySQL_Connection(Client *client_instance) :
         MySQL_Packet(client_instance) {}
-    boolean connect(IPAddress server, int port, char *user, char *password,
-                    char *db=NULL);
+    // boolean connect(IPAddress server, int port, char *user, char *password,
+    //                 char *db=NULL);
+    // Modify 'char *' into 'const char *const' so that const string can be used here
+    boolean connect(IPAddress server, int port, const char *const user,
+                    const char *const password, const char *const db = NULL);
     int connected() { return client->connected(); }
     const char *version() { return MYSQL_VERSION_STR; }
     void close();

--- a/src/MySQL_Encrypt_Sha1.cpp
+++ b/src/MySQL_Encrypt_Sha1.cpp
@@ -86,12 +86,14 @@ void Encrypt_SHA1::addUncounted(uint8_t data) {
 size_t Encrypt_SHA1::write(uint8_t data) {
   ++byteCount;
   addUncounted(data);
+  return 1; // The function 'write' didn't return avalue. Return a value to disable the warning
 }
 
 size_t Encrypt_SHA1::write(uint8_t* data, int length) {
   for (int i=0; i<length; i++) {
     write(data[i]);
   }
+  return length; // The function 'write' didn't return avalue. Return a value to disable the warning
 }
 
 void Encrypt_SHA1::pad() {

--- a/src/MySQL_Packet.cpp
+++ b/src/MySQL_Packet.cpp
@@ -520,7 +520,7 @@ void MySQL_Packet::store_int(byte *buff, long value, int size) {
 */
 int MySQL_Packet::read_lcb_int(int offset) {
   int len_size = 0;
-  int size = 0;
+  //int size = 0; // The variable 'size' is unused. Comment it to disable the warning
   int value = 0;
   if (!buffer)
       return -1;

--- a/src/MySQL_Packet.cpp
+++ b/src/MySQL_Packet.cpp
@@ -94,9 +94,12 @@ void MySQL_Packet::show_error(const char *msg, bool EOL) {
   password[in]    password
   db[in]          default database
 */
-void MySQL_Packet::send_authentication_packet(char *user, char *password,
-                                              char *db)
-{
+//void MySQL_Packet::send_authentication_packet(char *user, char *password,
+//                                              char *db)
+// Modify 'char *' into 'const char *const' so that const string can be used here
+void MySQL_Packet::send_authentication_packet(
+  const char *const user, const char *const password, const char *const db
+) {
   if (buffer != NULL)
     free(buffer);
 
@@ -175,7 +178,9 @@ void MySQL_Packet::send_authentication_packet(char *user, char *password,
 
   Returns boolean - True = scramble succeeded
 */
-boolean MySQL_Packet::scramble_password(char *password, byte *pwd_hash) {
+//boolean MySQL_Packet::scramble_password(char *password, byte *pwd_hash) {
+// Modify 'char *' into 'const char *const' so that const string can be used here
+boolean MySQL_Packet::scramble_password(const char *const password, byte *pwd_hash) {
   byte *digest;
   byte hash1[20];
   byte hash2[20];

--- a/src/MySQL_Packet.h
+++ b/src/MySQL_Packet.h
@@ -63,10 +63,15 @@ class MySQL_Packet {
 
     MySQL_Packet(Client *client_instance);
     boolean complete_handshake(char *user, char *password);
-    void send_authentication_packet(char *user, char *password,
-                                    char *db=NULL);
+    // void send_authentication_packet(char *user, char *password,
+    //                                 char *db=NULL);
+    // Modify 'char *' into 'const char *const' so that const string can be used here
+    void send_authentication_packet(const char *const user, const char *const password,
+                                    const char *const db = NULL);
     void parse_handshake_packet();
-    boolean scramble_password(char *password, byte *pwd_hash);
+    //boolean scramble_password(char *password, byte *pwd_hash);
+    // Modify 'char *' into 'const char *const' so that const string can be used here
+    boolean scramble_password(const char *const password, byte *pwd_hash);
     void read_packet();
     int get_packet_type();
     void parse_error_packet();


### PR DESCRIPTION
I noticed that there were some warnings when compiling and constant strings could not be used in 'MySQL_Connection::connect'. I modified it and thought these solved after testing. It is my great honour to contribute to this project and I hope these can be useful to it.
Best wishes.